### PR TITLE
Fix loadReferenceSchema and loadReferenceOptions

### DIFF
--- a/src/js/connectors/cloudcms.js
+++ b/src/js/connectors/cloudcms.js
@@ -316,7 +316,7 @@
         {
             var self = this;
 
-            return self.loadSchema(schemaIdentifier, successCallback, errorCallback);
+            return self.loadSchema(schemaIdentifier, null, successCallback, errorCallback);
         },
 
         /**
@@ -330,7 +330,7 @@
         {
             var self = this;
 
-            return self.loadOptions(optionsIdentifier, successCallback, errorCallback);
+            return self.loadOptions(optionsIdentifier, null, successCallback, errorCallback);
         },
 
         /**


### PR DESCRIPTION
schema loading via reference to another CMS object fails due to misplaced parameters